### PR TITLE
Add debian-installer `live` option to lb invocation.

### DIFF
--- a/build
+++ b/build
@@ -47,5 +47,5 @@ clone https://github.com/sugarlabs/write-activity       Write.activity
 [ ! -e /usr/bin/lb ] && apt install -y live-build
 
 # run live-build
-lb config -d buster
+lb config -d buster --debian-installer live
 lb build


### PR DESCRIPTION
Provides non-graphical installation of and from the booted image.

Fixes #9