### PR TITLE
Fix the gray-out bug in the nouveau DRI2 driver by disabling nouveau …

### DIFF
--- a/src/config/hooks/normal/0900-fix-DRI2-bug.hook.chroot
+++ b/src/config/hooks/normal/0900-fix-DRI2-bug.hook.chroot
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Written by Martin Guy <martinwguy@sugarlabs.org>
+# Public Domain
+
+# See https://github.com/sugarlabs/sugar-live-build/issues/20
+
+set -e
+
+rm /usr/lib/*-linux-gnu/dri/nouveau_dri.so


### PR DESCRIPTION
…DRI2

With certain nVidia cards, https://github.com/login flashes the login box
twice and then makes the tab all gray and gmail.com's login box flashes
between the right thing and all gray repeatedly.
This seems to be a bug in the nouveau DRI2 driver; this disables that so
X starts up with the nouveau driver without DRI2 accelleration.
See https://github.com/sugarlabs/sugar-live-build/issues/20