### PR TITLE
Fix the metacity overlay bug by installing a later version of metacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,6 @@ Rebuilding Sugar Live Build is not necessary if you just want to use it.  You on
 git clone https://github.com/sugarlabs/sugar-live-build.git
 ```
 
-2.5. (optional) Work around a bug in Metacity 3.30 which causes the Journal
-to open raised on startup, obscuring the Home View
-(or you can press F3 when it does this)
-```bash
-src=https://snapshot.debian.org/archive/debian/20190910T220103Z/pool/main/m/metacity
-dir=src/config/packages.chroot
-arch=$(dpkg --print-architecture)
-wget -P $dir \
-    $src/metacity_3.34.0-1_$arch.deb \
-    $src/libmetacity1_3.34.0-1_$arch.deb \
-    $src/metacity-common_3.34.0-1_all.deb
-```
-
 3. Run the `build` script.
 ```bash
 ./build

--- a/auto/config
+++ b/auto/config
@@ -47,6 +47,7 @@ clone https://github.com/sugarlabs/memorize-activity Memorize.activity
 # live build configuration step
 lb config noauto \
    --distribution buster \
+   --architectures i386 \
    --debian-installer live
 	"${@}"
 

--- a/build
+++ b/build
@@ -11,6 +11,15 @@ rm -rvf config chroot
 # clean build system
 lb clean --all
 
+# Work round a metacity bug that makes the Journal open full screen
+# obscuring the Home page.
+src=https://snapshot.debian.org/archive/debian/20190910T220103Z/pool/main/m/metacity
+dir=src/config/packages.chroot
+wget -c -P $dir \
+    $src/metacity_3.34.0-1_i386.deb \
+    $src/libmetacity1_3.34.0-1_i386.deb \
+    $src/metacity-common_3.34.0-1_all.deb
+
 # begin configuration
 lb config
 


### PR DESCRIPTION
Debian buster's metacity-3.30 has a bug that makes windows that are
opened iconified open full-screen instead, making the Journal overlay
the Home page. This fixes that by installing metacity 3.34, the first
fixed one.

Strangely, metacity 3.34 i386 depends on libc6>=2.28 like 3.30
but the amd64 package depends on libc6>=2.29, which leads to dependency hell.
As a result, this also makes SLB build for i386 by default.

See https://github.com/sugarlabs/sugar-live-build/issues/22